### PR TITLE
switch to update EOS syntax

### DIFF
--- a/Formula/docker-credential-ecr-login.rb
+++ b/Formula/docker-credential-ecr-login.rb
@@ -24,7 +24,7 @@ class DockerCredentialEcrLogin < Formula
   end
 
   def caveats
-    <<-EOS.undent
+    <<~EOS
       Update the contents of your ~/.docker/config.json file to either include:
 
       {


### PR DESCRIPTION
As per https://github.com/Homebrew/homebrew-cask/issues/49716#issuecomment-406644285

Currently can't install this via `brew install docker-credential-ecr-login` 